### PR TITLE
Fix instances of restoreConsole (deprecated in plot)

### DIFF
--- a/vmstools/R/getMetierClusters.r
+++ b/vmstools/R/getMetierClusters.r
@@ -373,19 +373,19 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(sizeClusters))[as.numeric(clusters)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_HAC',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_HAC',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(sizeClusters))[as.numeric(clusters)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_HAC',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_HAC',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,2], datLog[,3], pch=21, bg=rainbow(length(sizeClusters))[as.numeric(clusters)], main="", xlab="Axis 2", ylab="Axis 3")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_2_3_HAC',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_2_3_HAC',sep="_"), type='png')
     dev.off()
 
 
@@ -457,7 +457,7 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     mat2=mat[,which(colnames(mat)%in%names(sp2))]
     cc <- colorRampPalette(c("white", "black"),space = "rgb", interpolate="spline")
     print(levelplot(mat2, cuts=4, aspect=1, xlab="", ylab="", col.regions=cc(5), at=c(0,20,40,60,80,100), scales=list(cex=0.7), colorkey=list(space="right", at=c(0,20,40,60,80,100), width=1.1)))
-    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png')
     dev.off()
 
 
@@ -758,19 +758,19 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(clusters$size))[as.numeric(clusters$cluster)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_Kmeans',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_Kmeans',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(clusters$size))[as.numeric(clusters$cluster)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_Kmeans',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_Kmeans',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,2], datLog[,3], pch=21, bg=rainbow(length(clusters$size))[as.numeric(clusters$cluster)], main="", xlab="Axis 2", ylab="Axis 3")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_2_3_Kmeans',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_2_3_Kmeans',sep="_"), type='png')
     dev.off()
 
 
@@ -834,7 +834,7 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     mat2=mat[,which(colnames(mat)%in%names(sp2))]
     cc <- colorRampPalette(c("white", "black"),space = "rgb", interpolate="spline")
     print(levelplot(mat2, cuts=4, aspect=1, xlab="", ylab="", col.regions=cc(5), at=c(0,20,40,60,80,100), scales=list(cex=0.7), colorkey=list(space="right", at=c(0,20,40,60,80,100), width=1.1)))
-    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png')
     dev.off()
 
 
@@ -1175,19 +1175,19 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(clusters$id.med))[as.numeric(clusters$clustering)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_PAM',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_PAM',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(clusters$id.med))[as.numeric(clusters$clustering)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_PAM',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_PAM',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,2], datLog[,3], pch=21, bg=rainbow(length(clusters$id.med))[as.numeric(clusters$clustering)], main="", xlab="Axis 2", ylab="Axis 3")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_2_3_PAM',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_2_3_PAM',sep="_"), type='png')
     dev.off()
 
     
@@ -1251,7 +1251,7 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     mat2=mat[,which(colnames(mat)%in%names(sp2))]
     cc <- colorRampPalette(c("white", "black"),space = "rgb", interpolate="spline")
     print(levelplot(mat2, cuts=4, aspect=1, xlab="", ylab="", col.regions=cc(5), at=c(0,20,40,60,80,100), scales=list(cex=0.7), colorkey=list(space="right", at=c(0,20,40,60,80,100), width=1.1)))
-    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png')
     dev.off()
 
 
@@ -1590,19 +1590,19 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(clusters$i.med))[as.numeric(clusters$clustering)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_CLARA',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_CLARA',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,1], datLog[,2], pch=21, bg=rainbow(length(clusters$i.med))[as.numeric(clusters$clustering)], main="", xlab="Axis 1", ylab="Axis 2")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_1_2_CLARA',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_1_2_CLARA',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot(datLog[,2], datLog[,3], pch=21, bg=rainbow(length(clusters$i.med))[as.numeric(clusters$clustering)], main="", xlab="Axis 2", ylab="Axis 3")
     abline(h=0, lty=2) ; abline(v=0, lty=2)
-    savePlot(filename=paste(analysisName,'projections_2_3_CLARA',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projections_2_3_CLARA',sep="_"), type='png')
     dev.off()
 
     # Catch profile of the dataset
@@ -1666,7 +1666,7 @@ getMetierClusters = function(datSpecies,datLog,analysisName="",methMetier="clara
     mat2=mat[,which(colnames(mat)%in%names(sp2))]
     cc <- colorRampPalette(c("white", "black"),space = "rgb", interpolate="spline")
     print(levelplot(mat2, cuts=4, aspect=1, xlab="", ylab="", col.regions=cc(5), at=c(0,20,40,60,80,100), scales=list(cex=0.7), colorkey=list(space="right", at=c(0,20,40,60,80,100), width=1.1)))
-    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'mean_profile_by_cluster_levelplot',sep="_"), type='png')
     dev.off()
 
     # OR #

--- a/vmstools/R/getTableAfterPCA.r
+++ b/vmstools/R/getTableAfterPCA.r
@@ -27,22 +27,22 @@ getTableAfterPCA = function(datSpecies,analysisName="",pcaYesNo="pca",criterion=
     
     X11(5,5)
     plot.PCA(log.pca, choix = "var", axes = 1:2, new.plot=FALSE, title="", lim.cos2.var = 0.1)
-    savePlot(filename=paste(analysisName,'species_projection_on_the_1_and_2_factorial_axis',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'species_projection_on_the_1_and_2_factorial_axis',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot.PCA(log.pca, choix = "var", axes = 1:2, new.plot=FALSE, title="", lim.cos2.var = 0.1)
-    savePlot(filename=paste(analysisName,'species_projection_on_the_1_and_2_factorial_axis',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'species_projection_on_the_1_and_2_factorial_axis',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot.PCA(log.pca, choix = "var", axes = 2:3, new.plot=FALSE, title="", lim.cos2.var = 0.1)
-    savePlot(filename=paste(analysisName,'species_projection_on_the_2_and_3_factorial_axis',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'species_projection_on_the_2_and_3_factorial_axis',sep="_"), type='png')
     dev.off()
     
     X11(5,5)
     plot.PCA(log.pca, choix = "ind", axes = 1:2, habillage = "ind", title="", new.plot=FALSE, cex=1.1)
-    savePlot(filename=paste(analysisName,'projection_of_individuals_on_the_first_two_factorial_axis',sep="_"), type='png', restoreConsole = TRUE)
+    savePlot(filename=paste(analysisName,'projection_of_individuals_on_the_first_two_factorial_axis',sep="_"), type='png')
     dev.off()
  
 

--- a/vmstools/R/selectMainSpecies.r
+++ b/vmstools/R/selectMainSpecies.r
@@ -48,7 +48,7 @@ selectMainSpecies=function(dat,analysisName="",RunHAC=TRUE,DiagFlag=FALSE){
         cah_cluster_var=cutree(cah_var,k=nb.finalclusters)
 
         png(paste(analysisName,"HAC_Dendogram_Step1.png",sep="_"), width = 1200, height = 800)
-        plclust(cah_var,labels=FALSE,hang=-1,ann=FALSE)
+        plot(cah_var,labels=FALSE,hang=-1,ann=FALSE)
         title(main="HAC dendogram",xlab="Species",ylab="Height")
         rect.hclust(cah_var, k=nb.finalclusters)
         dev.off()
@@ -97,7 +97,7 @@ selectMainSpecies=function(dat,analysisName="",RunHAC=TRUE,DiagFlag=FALSE){
 
         # Dendogram of the first cut in the residual species cluster
         png(paste(analysisName,"HAC_Dendogram_Step1_ResidualSpecies.png",sep="_"), width = 1200, height = 800)
-        plclust(cah_var,labels=FALSE,hang=-1,ann=FALSE)
+        plot(cah_var,labels=FALSE,hang=-1,ann=FALSE)
         title(main="HAC dendogram - Step",xlab="Species",ylab="Height")
         if((nb.finalclusters+nb_cut)>=(p-2)){
           rect.hclust(cah_var, k=kFinal)


### PR DESCRIPTION
A fix for the plot command in the selectMainSpecies and getMetierClusters functions.  Two issues:

i)  The restoreConsole flag is no longer present in Plot so instances are removed
ii) plclust has been replaced by a generic 'plot', so I have done this.

It was causing the two functions to fail and not complete. This fixes that issue and practical 2i can now be run again.

